### PR TITLE
3 add logging api

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,22 @@
+#include <stdlib.h>
 #include <sys/log.h>
 #include <yacc/parser.tab.h>
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG
 
+void notify_exit(void)
+{
+    DEBUG("Exiting gemstone...");
+}
+
 void setup(void)
 {
     log_init();
     DEBUG("starting gemstone...");
+
+    #if LOG_LEVEL <= LOG_LEVEL_DEBUG
+    atexit(&notify_exit);
+    #endif
 
     DEBUG("finished starting up gemstone...");
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,19 @@
+#include <sys/log.h>
 #include <yacc/parser.tab.h>
 
+#define LOG_LEVEL LOG_LEVEL_DEBUG
+
+void setup(void)
+{
+    log_init();
+    DEBUG("starting gemstone...");
+
+    DEBUG("finished starting up gemstone...");
+}
+
 int main() {
+    setup();
+
     yyparse();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@ void setup(void)
     DEBUG("finished starting up gemstone...");
 }
 
-int main() {
+int main(void) {
     setup();
 
     yyparse();

--- a/src/main.c
+++ b/src/main.c
@@ -4,19 +4,31 @@
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG
 
+/**
+ * @brief Log a debug message to inform about beginning exit procedures
+ * 
+ */
 void notify_exit(void)
 {
     DEBUG("Exiting gemstone...");
 }
 
+/**
+ * @brief Run compiler setup here
+ * 
+ */
 void setup(void)
 {
+    // setup preample
+
     log_init();
     DEBUG("starting gemstone...");
 
     #if LOG_LEVEL <= LOG_LEVEL_DEBUG
     atexit(&notify_exit);
     #endif
+
+    // actual setup
 
     DEBUG("finished starting up gemstone...");
 }

--- a/src/sys/log.c
+++ b/src/sys/log.c
@@ -16,6 +16,9 @@ void log_init(void)
 
 void log_register_stream(FILE* restrict stream)
 {
+    if (stream == NULL)
+        PANIC("stream to register is NULL");
+
     if (GlobalLogger.stream_count == 0)
     {
         GlobalLogger.streams = (FILE**) malloc(sizeof(FILE*));

--- a/src/sys/log.c
+++ b/src/sys/log.c
@@ -1,0 +1,110 @@
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/log.h>
+
+static struct Logger_t {
+    FILE** streams;
+    size_t stream_count;
+} GlobalLogger;
+
+void log_init(void)
+{
+    log_register_stream(LOG_DEFAULT_STREAM);
+}
+
+void log_register_stream(FILE* restrict stream)
+{
+    if (GlobalLogger.stream_count == 0)
+    {
+        GlobalLogger.streams = (FILE**) malloc(sizeof(FILE*));
+        GlobalLogger.stream_count = 1;
+
+        if (GlobalLogger.streams == NULL)
+        {
+            PANIC("failed to allocate stream buffer");
+        }   
+    }
+    else
+    {
+        GlobalLogger.stream_count++;
+        size_t bytes = GlobalLogger.stream_count * sizeof(FILE*);
+        GlobalLogger.streams = (FILE**) realloc(GlobalLogger.streams, bytes);
+
+        if (GlobalLogger.streams == NULL)
+        {
+            PANIC("failed to reallocate stream buffer");
+        }
+    }
+
+    GlobalLogger.streams[GlobalLogger.stream_count - 1] = stream;
+}
+
+static void vflogf(
+    FILE* restrict stream,
+    const char* restrict level,
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    va_list args)
+{
+    fprintf(stream, "%s in %s() at %s:%lu: ", level, func, file, line);
+    vfprintf(stream, format, args);
+}
+
+void __logf(
+    const char* restrict level,
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    for (size_t i = 0; i < GlobalLogger.stream_count; i++)
+    {
+        FILE* stream = GlobalLogger.streams[i];
+
+        vflogf(stream, level, file, line, func, format, args);
+    }
+
+    va_end(args);
+}
+
+void __panicf(
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    vflogf(stderr, LOG_STRING_PANIC, file, line, func, format, args);
+
+    va_end(args);
+
+    exit(EXIT_FAILURE);
+}
+
+void __fatalf(
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    vflogf(stderr, LOG_STRING_FATAL, file, line, func, format, args);
+
+    va_end(args);
+
+    abort();
+}

--- a/src/sys/log.h
+++ b/src/sys/log.h
@@ -1,0 +1,81 @@
+#ifndef _SYS_ERR_H_
+#define _SYS_ERR_H_
+
+#include <stdio.h>
+#include <sys/cdefs.h>
+
+#define LOG_DEFAULT_STREAM stderr
+
+#define LOG_LEVEL_ERROR         3
+#define LOG_LEVEL_WARNING       2
+#define LOG_LEVEL_INFORMATION   1
+#define LOG_LEVEL_DEBUG         0
+
+#define LOG_LEVEL LOG_LEVEL_DEBUG
+
+#define LOG_MAX_BACKTRACE_FRAMES 64
+
+#define LOG_STRING_PANIC       "Critical"
+#define LOG_STRING_FATAL       "Fatal"
+#define LOG_STRING_ERROR       "Error"
+#define LOG_STRING_WARNING     "Warning"
+#define LOG_STRING_INFORMATION "Information"
+#define LOG_STRING_DEBUG       "Debug"
+
+/**
+ * @brief Panic is used in cases where the process is in an unrecoverable state.
+ *        This macro will print debug information to stderr and call abort() to
+ *        performa a ungracefull exit. No clean up possible.
+ */
+#define PANIC(format, ...) __panicf(__FILE_NAME__, __LINE__, __func__, format"\n", ##__VA_ARGS__)
+
+/**
+ * @brief Panic is used in cases where the process is in an invalid or undefined state.
+ *        This macro will print debug information to stderr and call exit() to
+ *        initiate a gracefull exit, giving the process the opportunity to clean up.
+ */
+#define FATAL(format, ...) __fatalf(__FILE_NAME__, __LINE__, __func__, format"\n", ##__VA_ARGS__)
+
+/*
+Standard log macros. These will not terminate the application.
+Can be turned off by setting LOG_LEVEL. All logs which have smaller log numbers
+will not print.
+*/
+#define ERROR(format, ...) __LOG(LOG_STRING_ERROR, LOG_LEVEL_ERROR, format"\n", ##__VA_ARGS__)
+#define WARN(format, ...) __LOG(LOG_STRING_WARNING, LOG_LEVEL_WARNING, format"\n", ##__VA_ARGS__)
+#define INFO(format, ...) __LOG(LOG_STRING_INFORMATION, LOG_LEVEL_INFORMATION, format"\n", ##__VA_ARGS__)
+#define DEBUG(format, ...) __LOG(LOG_STRING_DEBUG, LOG_LEVEL_DEBUG, format"\n", ##__VA_ARGS__)
+
+#define __LOG(level, priority, format, ...) \
+    do { \
+        if (LOG_LEVEL <= priority) \
+            __logf(level, __FILE_NAME__, __LINE__, __func__, format, ##__VA_ARGS__); \
+    } while(0)
+
+void __logf(
+    const char* restrict level,
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...);
+
+void __panicf(
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...);
+
+void __fatalf(
+    const char* restrict file,
+    const unsigned long line,
+    const char* restrict func,
+    const char* restrict format,
+    ...);
+
+void log_init(void);
+
+void log_register_stream(FILE* restrict stream);
+
+#endif /* _SYS_ERR_H_ */

--- a/src/sys/log.h
+++ b/src/sys/log.h
@@ -13,8 +13,6 @@
 
 #define LOG_LEVEL LOG_LEVEL_DEBUG
 
-#define LOG_MAX_BACKTRACE_FRAMES 64
-
 #define LOG_STRING_PANIC       "Critical"
 #define LOG_STRING_FATAL       "Fatal"
 #define LOG_STRING_ERROR       "Error"

--- a/src/sys/log.h
+++ b/src/sys/log.h
@@ -52,6 +52,16 @@ will not print.
             __logf(level, __FILE_NAME__, __LINE__, __func__, format, ##__VA_ARGS__); \
     } while(0)
 
+/**
+ * @brief Log a message into all registered streams
+ * 
+ * @param level of the message
+ * @param file origin of the message cause
+ * @param line line in which log call was made
+ * @param func function the log call was done in 
+ * @param format the format to print following args in
+ * @param ... 
+ */
 void __logf(
     const char* restrict level,
     const char* restrict file,
@@ -60,6 +70,15 @@ void __logf(
     const char* restrict format,
     ...);
 
+/**
+ * @brief Log a panic message to stderr and perform gracefull crash with exit() denoting a failure
+ * 
+ * @param file origin of the message cause
+ * @param line line in which log call was made
+ * @param func function the log call was done in 
+ * @param format the format to print following args in
+ * @param ... 
+ */
 void __panicf(
     const char* restrict file,
     const unsigned long line,
@@ -67,6 +86,15 @@ void __panicf(
     const char* restrict format,
     ...);
 
+/**
+ * @brief Log a critical message to stderr and perform ungracefull crash with abort()
+ * 
+ * @param file origin of the message cause
+ * @param line line in which log call was made
+ * @param func function the log call was done in 
+ * @param format the format to print following args in
+ * @param ... 
+ */
 void __fatalf(
     const char* restrict file,
     const unsigned long line,
@@ -74,8 +102,17 @@ void __fatalf(
     const char* restrict format,
     ...);
 
+/**
+ * @brief Initialize the logger by registering stderr as stream
+ * 
+ */
 void log_init(void);
 
+/**
+ * @brief Register a stream as output source. Must be freed manually at exit if necessary 
+ * 
+ * @param stream 
+ */
 void log_register_stream(FILE* restrict stream);
 
 #endif /* _SYS_ERR_H_ */


### PR DESCRIPTION
# Logging API

Added a simple logger API. This is meant to be used as compiler INTERNAL logging NOT for printing messages about syntax errors.

## Logging

for using the logger include `<sys/log.h>`.
Then call one of the following macros in order to make a log message:
- `ERROR`
- `WARN`
- `INFO`
- `DEBUG`

Each of those functions takes arguments similar to `printf`. A format string and optional arguments. They can be used in the following ways:

```c
#include <sys/log.h>

void foo(void)
{
    ERROR("this is an error message!");
    DEBUG("this a debug message!");

    int a = 10;
    float d = 0.3;

   INFO("formatted output: %d, %f", a, d);
}
```

By setting the macro `LOG_LEVEL` only messages with a higher log level will be logged.
If set to `LOG_LEVEL_WARN` only errors and warnings will be printed.
Default level for now is `LOG_LEVEL_DEBUG`.
Logs which not get printed should get optimized out of the binary.

## Crashes

There are two special functions: `PANIC` and `FATAL` both take the same arguments as the other logging functions.
`PANIC` will print only to `stderr` and the call `exit`, closing the program. All functions registered with `atexit` will be run.
`FATAL` will also print only to `stderr` but will cal `abort` terminating immediately.
ONLY use these two for critical sections in which no recovery is possible. Otherwise use one of the others.

## Custom logger

Other output streams can be registered with `log_register_stream`.
Example:

```c

FILE* file = fopen("gemstone.log", "w");

log_register_stream(file);

DEBUG("log to stderr and a file!");
```