### PR TITLE
8 add GitHub action for code check

### DIFF
--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -1,0 +1,14 @@
+name: "Build check gemstone in SDK"
+run-name: SDK build check to ${{ inputs.deploy_target }} by @${{ github.actor }}
+on: [push, pull_request]
+env:
+  SDK: 0.1.0-alma-9.3
+jobs:
+  test-rust:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup SDK
+      run: docker pull servostar/gemstone:sdk-"$SDK" && docker build --tag gemstone:devkit-"$SDK" .
+    - name: Compile
+      run: docker run gemstone:devkit-"$SDK" make -B release

--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   SDK: 0.1.0-alma-9.3
 jobs:
-  test-rust:
+  build-check-sdk:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -11,4 +11,4 @@ jobs:
     - name: Setup SDK
       run: docker pull servostar/gemstone:sdk-"$SDK" && docker build --tag gemstone:devkit-"$SDK" .
     - name: Compile
-      run: docker run gemstone:devkit-"$SDK" make -B release
+      run: docker run gemstone:devkit-"$SDK" make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,28 @@ target_compile_options(debug PUBLIC ${FLAGS} -g)
 
 # add src directory as include path
 target_include_directories(debug PUBLIC src)
+
+# ------------------------------------------------ #
+#  Target Code Check                               #
+# ------------------------------------------------ #
+
+# Same as debug but will fail on warnings
+# use as check
+
+add_executable(check
+        ${SOURCE_FILES}
+        ${LEX_GENERATED_SOURCE_FILE}
+        ${YACC_GENERATED_SOURCE_FILE})
+
+set_target_properties(check
+        PROPERTIES
+        OUTPUT_NAME "gsc"
+        RUNTIME_OUTPUT_DIRECTORY "bin/check")
+
+# compiler flags targeting a GCC debug environment
+# extra -Werror flag to treat warnings as error to make github action fail on warning
+target_compile_options(check PUBLIC ${FLAGS} -g -Werror)
+
+# add src directory as include path
+target_include_directories(check PUBLIC src)
+

--- a/src/lex/lexer.l
+++ b/src/lex/lexer.l
@@ -6,6 +6,11 @@
     int yylex();
 %}
 
+// disable the following functions
+// to avoid failing code check
+%option nounput
+%option noinput
+
 %%
 .;
 %%

--- a/src/lex/lexer.l
+++ b/src/lex/lexer.l
@@ -6,8 +6,8 @@
     int yylex();
 %}
 
-// disable the following functions
-// to avoid failing code check
+/* disable the following functions */
+/* to avoid failing code check */
 %option nounput
 %option noinput
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 #include <yacc/parser.tab.h>
 
 int main() {
-    yyparse();
+    yypa rse();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 #include <yacc/parser.tab.h>
 
 int main() {
-    yypa rse();
+    yyparse();
     return 0;
 }


### PR DESCRIPTION
Added github action which checks for successfull compilation of gemstone.
For this purpose a new target was added to CMakeLists.txt which treats warnings as errors.
The action will pull the docker SDK and build the DEVKIT upon which a clean build of target check is made.
This setup can be reproduced locally with the commands provided b the action and preemptive checking can be done locally.

The branch is in a state which makes the check fail. This behavior will be fixed by issue #11 and should be ignored for this PR.
A rule to make passing of the check mandatory for merging will be made by issue #10.