### PR TITLE
18 write new sdk based on alpine to run newer gcc version 114

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM servostar/gemstone:sdk-0.1.0-alma-9.3
+FROM servostar/gemstone:sdk-0.2.0-alpine-3.19.1
 LABEL authors="servostar"
-LABEL version="0.1.0"
+LABEL version="0.2.0"
 LABEL description="docker image for setting up the build pipeline on SDK"
 LABEL website="https://github.com/Servostar/gemstone"
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,13 +1,13 @@
-FROM almalinux:9.3
+FROM alpine:3.19.1
 LABEL authors="servostar"
-LABEL version="0.1.0"
+LABEL version="0.2.0"
 LABEL description="base image for building the gemstone programming language compiler"
 LABEL website="https://github.com/Servostar/gemstone"
 
 # install dependencies
-RUN yum install cmake gcc flex byacc -y
+RUN apk add build-base gcc make cmake bison flex
 
 # create user for build
-RUN adduser lorang
+RUN adduser --disabled-password lorang
 WORKDIR /home/lorang
 USER lorang

--- a/src/sys/log.h
+++ b/src/sys/log.h
@@ -2,7 +2,6 @@
 #define _SYS_ERR_H_
 
 #include <stdio.h>
-#include <sys/cdefs.h>
 #include <string.h>
 
 #define LOG_DEFAULT_STREAM stderr


### PR DESCRIPTION
Added new docker SDK. Switched from Almalinux 9.3 to Alpine 3.19.1. GCC version bumped from 11.4 to 13.1.
Also removed unnecessary header from sys/log.h