### PR TITLE
added parser rule for function calling

### DIFF
--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -56,8 +56,7 @@
 %token FunExtsupport
 
 %%
-program: assign
-    | definition;
+program: funcall;
 
 expr: ValFloat
     | ValInt
@@ -69,7 +68,10 @@ exprlist: expr ',' exprlist
         | expr
         | ;
 
-funcall: Ident '(' exprlist ')' { DEBUG("Function call"); };
+paramlist: paramlist '(' exprlist ')'
+    | ;
+
+funcall: Ident paramlist { DEBUG("Function call"); };
 
 assign: Ident '=' expr { DEBUG("Assignment"); };
 

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -65,6 +65,12 @@ expr: ValFloat
     | ValStr
     | Ident;
 
+exprlist: expr ',' exprlist
+        | expr
+        | ;
+
+funcall: Ident '(' exprlist ')' { DEBUG("Function call"); };
+
 assign: Ident '=' expr { DEBUG("Assignment"); };
 
 identlist: Ident ',' identlist


### PR DESCRIPTION
Added a parser rule for detecting function calls.
A function is made out of an identifier and a list of expressions separated by commas.