### PR TITLE
36 add parser rule for if

### DIFF
--- a/src/lex/lexer.l
+++ b/src/lex/lexer.l
@@ -15,6 +15,8 @@
 %%
 "\n"    yyLineNumber++;
 
+#.* ;
+
 ":" {DEBUG("\"%s\" tokenized with \':\'", yytext); return(':');};
 "=" {DEBUG("\"%s\" tokenized with \'=\'", yytext); return('=');};
 "+" {DEBUG("\"%s\" tokenized with \'+\'", yytext); return('+');};
@@ -24,7 +26,6 @@
 "," {DEBUG("\"%s\" tokenized with \',\'", yytext); return(',');};
 ";" {DEBUG("\"%s\" tokenized with \';\'", yytext); return(';');};
 "." {DEBUG("\"%s\" tokenized with \'.\'", yytext); return('.');};
-"#" {DEBUG("\"%s\" tokenized with \'#\'", yytext); return('#');};
 
 "(" {DEBUG("\"%s\" tokenized with \'(\'", yytext); return('(');};
 ")" {DEBUG("\"%s\" tokenized with \')\'", yytext); return(')');};

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -56,7 +56,7 @@
 %token FunExtsupport
 
 %%
-program: statement;
+program: statementlist;
 
 
 expr: ValFloat
@@ -65,9 +65,23 @@ expr: ValFloat
     | ValStr
     | Ident;
 
+statementlist: statementlist statement
+    | ;
+
 statement: assign
         | decl
-        | definition;
+        | definition
+        | branch;
+
+branchif: KeyIf expr '{' statementlist '}' { DEBUG("if"); };
+branchelse: KeyElse '{' statementlist '}' { DEBUG("if-else"); };
+branchelseif: KeyElse KeyIf expr '{' statementlist '}' { DEBUG("else-if"); };
+
+branchelseifs: branchelseifs branchelseif
+    | ;
+
+branch: branchif branchelseifs
+    | branchif branchelseifs branchelse;
 
 identlist: Ident ',' identlist
         | Ident

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -56,8 +56,8 @@
 %token FunExtsupport
 
 %%
-program: assign
-    | definition;
+program: statement;
+
 
 expr: ValFloat
     | ValInt
@@ -65,15 +65,35 @@ expr: ValFloat
     | ValStr
     | Ident;
 
-assign: Ident '=' expr { DEBUG("Assignment"); };
+statement: assign
+        | decl
+        | definition;
+
+
+
 
 identlist: Ident ',' identlist
         | Ident
         | ;
 
+
 decl: type ':' identlist { DEBUG("Declaration"); };
 
+
+
+
+
+
 definition: decl '=' expr { DEBUG("Definition"); };
+
+assign: Ident '=' expr { DEBUG("Assignment"); };
+
+
+
+
+
+
+
 
 sign: KeySigned
     | KeyUnsigned
@@ -88,8 +108,6 @@ scale: scale KeyShort
 type: sign scale Ident
     | sign scale KeyInt
     | sign scale KeyFloat;
-
-
 
 %%
 

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -69,31 +69,15 @@ statement: assign
         | decl
         | definition;
 
-
-
-
 identlist: Ident ',' identlist
         | Ident
         | ;
 
-
 decl: type ':' identlist { DEBUG("Declaration"); };
-
-
-
-
-
 
 definition: decl '=' expr { DEBUG("Definition"); };
 
 assign: Ident '=' expr { DEBUG("Assignment"); };
-
-
-
-
-
-
-
 
 sign: KeySigned
     | KeyUnsigned


### PR DESCRIPTION
Added rules for branches.
A branch (if) is an `if <expr> {}` followed by a variable amount of `else if <expr>` and an ended by an optional `else`.
Valid combinations are:
```cpp
if 5 {
}
```
```cpp
if 5 {
} else {}
```
```cpp
if 5 {
} else if 7 {}
else if 9 {}
else if 12 {}
else {}
```