### PR TITLE
refactored transmute rule and added bracketed expressions

### DIFF
--- a/src/lex/lexer.l
+++ b/src/lex/lexer.l
@@ -52,6 +52,7 @@
 "float" {DEBUG("\"%s\" tokenized with \'KeyFloat\'", yytext); return(KeyFloat);};
 "self" {DEBUG("\"%s\" tokenized with \'KeySelf\'", yytext); return(KeySelf);};
 "as" {DEBUG("\"%s\" tokenized with \'KeyAs'", yytext); return (KeyAs);};
+"to" {DEBUG("\"%s\" tokenized with \'KeyTo'", yytext); return (KeyTo);};
 "short" {DEBUG("\"%s\" tokenized with \'KeyShort\'", yytext); return(KeyShort);};
 "long" {DEBUG("\"%s\" tokenized with \'KeyLong\'", yytext); return(KeyLong);};
 "half" {DEBUG("\"%s\" tokenized with \'KeyHalf\'", yytext); return(KeyHalf);};

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -72,6 +72,7 @@
 %token KeyFloat
 %token KeySelf
 %token KeyAs
+%token KeyTo
 %token <string> ValInt
 %token <string> Ident
 %token <string> ValFloat 
@@ -128,7 +129,7 @@
 %left '+' '-'
 %left '*' '/'
 %left OpNot OpBitnot
-%left KeyAs
+%left KeyAs KeyTo
 %left '(' ')'
 
 %%
@@ -154,6 +155,7 @@ expr: ValFloat {$$ = AST_new_node(AST_Float, $1);}
     | boxselfaccess{$$ = $1;}
     | typecast{$$ = $1;}
     | reinterpretcast{$$ = $1;}
+    | '(' expr ')' {$$=$2;}
 
 exprlist: expr ',' exprlist {AST_push_node($3, $1);
                              $$ = $3;}
@@ -289,9 +291,9 @@ typecast: expr KeyAs type %prec KeyAs  {AST_NODE_PTR cast = AST_new_node(AST_Typ
                                         $$ = cast;
                                          DEBUG("Type-Cast"); };
 
-reinterpretcast: '(' type ')' expr { AST_NODE_PTR cast = AST_new_node(AST_Transmute, NULL);
-                                      AST_push_node(cast, $4);
-                                        AST_push_node(cast, $2);
+reinterpretcast: expr KeyTo type %prec KeyTo { AST_NODE_PTR cast = AST_new_node(AST_Transmute, NULL);
+                                      AST_push_node(cast, $1);
+                                        AST_push_node(cast, $3);
                                         $$ = cast;
                                     DEBUG("Reinterpret-Cast"); };
 


### PR DESCRIPTION
Changes transmute rule:
`(int) 78)` ==> `78 to int`

Expressions can be surrounded by parenthesis in order to group them