### PR TITLE
76 add rules for references

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -84,6 +84,9 @@ void AST_init() {
   lookup_table[AST_Negate] = "-";
   lookup_table[AST_Parameter] = "parameter";
   lookup_table[AST_ParamDecl] = "parameter-declaration";
+  lookup_table[AST_AddressOf] = "address of";
+  lookup_table[AST_Dereference] = "deref";
+  lookup_table[AST_Reference] = "ref";
 }
 
 const char* AST_node_to_string(const struct AST_Node_t* node) {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -76,6 +76,9 @@ enum AST_SyntaxElement_t {
   AST_Parameter,
   AST_Qualifyier,
   AST_ParamDecl,
+  AST_AddressOf,
+  AST_Dereference,
+  AST_Reference,
   AST_ELEMENT_COUNT
 };
 

--- a/src/lex/lexer.l
+++ b/src/lex/lexer.l
@@ -98,7 +98,7 @@
     yytext[yyleng - 2] = 0;
     
     DEBUG("\"%s\" tokenized with \'ValStr\'", yytext); yylval.string = strdup(yytext); return(ValStr);};
-\"\"\"([^\"\n]|\\\n)*\"\"\" {
+\"\"\"[^\"]*\"\"\" {
     yytext = yytext +3;
     yytext[yyleng - 4] = 0;
 

--- a/src/yacc/parser.y
+++ b/src/yacc/parser.y
@@ -132,7 +132,7 @@
 %left '*' '/'
 %left OpNot OpBitnot
 %left KeyAs KeyTo
-%left '(' ')'
+%left '(' ')' '[' ']'
 
 %%
 program: program programbody {AST_push_node(root, $2);}
@@ -158,6 +158,13 @@ expr: ValFloat {$$ = AST_new_node(new_loc(), AST_Float, $1);}
     | typecast{$$ = $1;}
     | reinterpretcast{$$ = $1;}
     | '(' expr ')' {$$=$2;}
+    | KeyRef Ident {AST_NODE_PTR addrof = AST_new_node(new_loc(), AST_AddressOf, NULL);
+                                   AST_push_node(addrof, AST_new_node(new_loc(), AST_Ident, $2));
+                                   $$ = addrof;}
+    | expr '[' expr ']' {AST_NODE_PTR deref = AST_new_node(new_loc(), AST_Dereference, NULL);
+                                   AST_push_node(deref, $1);
+                                   AST_push_node(deref, $3);
+                                   $$ = deref;};
 
 exprlist: expr ',' exprlist {AST_push_node($3, $1);
                              $$ = $3;}
@@ -449,7 +456,10 @@ type: typekind {AST_NODE_PTR type = AST_new_node(new_loc(), AST_Type, NULL);
                 AST_push_node(type, $1);
                 AST_push_node(type, $2);
                 AST_push_node(type, $3);
-                $$ = type;};
+                $$ = type;}
+    | KeyRef type {AST_NODE_PTR reftype = AST_new_node(new_loc(), AST_Reference, NULL);
+               AST_push_node(reftype, $2);
+               $$ = reftype; };
 
 operation: oparith {$$ = $1;}
     | oplogic {$$ = $1;}

--- a/tests/ast/test_ast.py
+++ b/tests/ast/test_ast.py
@@ -81,6 +81,9 @@ def run_check_print_node():
 50 parameter
 51 value
 52 parameter-declaration
+53 address of
+54 deref
+55 ref
 """ == p.stdout
 
 


### PR DESCRIPTION
Added parser rules for:
- Reference type definition: `type ref int: int_ptr`
- Dereference: `foo[0][1]`
- Taking the reference (memory location) of an variable: `ref int: b = ref a`

Example:
```
int: a = 5
ref int: b = ref a
int: c = a[0]
```